### PR TITLE
CRUD 구현, optimistic update 처리, type interface 선언 

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -59,6 +59,7 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.8.3"],\
           ["react", "npm:19.2.4"],\
           ["react-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:19.2.4"],\
+          ["react-hot-toast", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:2.6.0"],\
           ["react-markdown", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:10.1.0"],\
           ["react-router-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.14.0"],\
           ["react-syntax-highlighter", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:16.1.1"],\
@@ -6932,6 +6933,28 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["goober", [\
+      ["npm:2.1.18", {\
+        "packageLocation": "../.yarn/berry/cache/goober-npm-2.1.18-65f12b498f-10c0.zip/node_modules/goober/",\
+        "packageDependencies": [\
+          ["goober", "npm:2.1.18"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:8ffb78e12e4d7c18555eba05c40c6b5e69e7e0a7121f6c1c424bf4557404376bcc36c92ee1264e25a5b2e94a562176f430ecd786f8eb2ace96bf83bc9f586846#npm:2.1.18", {\
+        "packageLocation": "./.yarn/__virtual__/goober-virtual-aedf57734e/2/.yarn/berry/cache/goober-npm-2.1.18-65f12b498f-10c0.zip/node_modules/goober/",\
+        "packageDependencies": [\
+          ["@types/csstype", null],\
+          ["csstype", "npm:3.2.3"],\
+          ["goober", "virtual:8ffb78e12e4d7c18555eba05c40c6b5e69e7e0a7121f6c1c424bf4557404376bcc36c92ee1264e25a5b2e94a562176f430ecd786f8eb2ace96bf83bc9f586846#npm:2.1.18"]\
+        ],\
+        "packagePeers": [\
+          "@types/csstype",\
+          "csstype"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["gopd", [\
       ["npm:1.2.0", {\
         "packageLocation": "../.yarn/berry/cache/gopd-npm-1.2.0-df89ffa78e-10c0.zip/node_modules/gopd/",\
@@ -10103,6 +10126,34 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["react-hot-toast", [\
+      ["npm:2.6.0", {\
+        "packageLocation": "../.yarn/berry/cache/react-hot-toast-npm-2.6.0-9b19dadc26-10c0.zip/node_modules/react-hot-toast/",\
+        "packageDependencies": [\
+          ["react-hot-toast", "npm:2.6.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:2.6.0", {\
+        "packageLocation": "./.yarn/__virtual__/react-hot-toast-virtual-8ffb78e12e/2/.yarn/berry/cache/react-hot-toast-npm-2.6.0-9b19dadc26-10c0.zip/node_modules/react-hot-toast/",\
+        "packageDependencies": [\
+          ["@types/react", "npm:19.2.14"],\
+          ["@types/react-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:19.2.3"],\
+          ["csstype", "npm:3.2.3"],\
+          ["goober", "virtual:8ffb78e12e4d7c18555eba05c40c6b5e69e7e0a7121f6c1c424bf4557404376bcc36c92ee1264e25a5b2e94a562176f430ecd786f8eb2ace96bf83bc9f586846#npm:2.1.18"],\
+          ["react", "npm:19.2.4"],\
+          ["react-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:19.2.4"],\
+          ["react-hot-toast", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:2.6.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/react-dom",\
+          "@types/react",\
+          "react-dom",\
+          "react"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["react-is", [\
       ["npm:16.13.1", {\
         "packageLocation": "../.yarn/berry/cache/react-is-npm-16.13.1-a9b9382b4f-10c0.zip/node_modules/react-is/",\
@@ -10263,6 +10314,7 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.8.3"],\
           ["react", "npm:19.2.4"],\
           ["react-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:19.2.4"],\
+          ["react-hot-toast", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:2.6.0"],\
           ["react-markdown", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:10.1.0"],\
           ["react-router-dom", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.14.0"],\
           ["react-syntax-highlighter", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:16.1.1"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -33,6 +33,7 @@ const RAW_RUNTIME_STATE =
           ["@babel/preset-react", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.28.5"],\
           ["@babel/preset-typescript", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.28.5"],\
           ["@eslint/js", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:10.0.1"],\
+          ["@octokit/types", "npm:16.0.0"],\
           ["@tailwindcss/postcss", "npm:4.2.2"],\
           ["@tanstack/react-query", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:5.96.2"],\
           ["@tanstack/react-query-devtools", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:5.96.2"],\
@@ -3083,6 +3084,25 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/@npmcli-redact-npm-4.0.0-b3e2eeb8d8-10c0.zip/node_modules/@npmcli/redact/",\
         "packageDependencies": [\
           ["@npmcli/redact", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@octokit/openapi-types", [\
+      ["npm:27.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/@octokit-openapi-types-npm-27.0.0-e607516b0f-10c0.zip/node_modules/@octokit/openapi-types/",\
+        "packageDependencies": [\
+          ["@octokit/openapi-types", "npm:27.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@octokit/types", [\
+      ["npm:16.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/@octokit-types-npm-16.0.0-da01afac91-10c0.zip/node_modules/@octokit/types/",\
+        "packageDependencies": [\
+          ["@octokit/openapi-types", "npm:27.0.0"],\
+          ["@octokit/types", "npm:16.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -10217,6 +10237,7 @@ const RAW_RUNTIME_STATE =
           ["@babel/preset-react", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.28.5"],\
           ["@babel/preset-typescript", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:7.28.5"],\
           ["@eslint/js", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:10.0.1"],\
+          ["@octokit/types", "npm:16.0.0"],\
           ["@tailwindcss/postcss", "npm:4.2.2"],\
           ["@tanstack/react-query", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:5.96.2"],\
           ["@tanstack/react-query-devtools", "virtual:540f4c9ece849d9ac7b9e983556b3dd36f9065fcb16848256de92d4c59cc231f05286d8a4ac0612e587b7634073797246ebf063d2b462af3480d6b40eed435a5#npm:5.96.2"],\

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/js": "^10.0.1",
+    "@octokit/types": "^16.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.14.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hot-toast": "^2.6.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.0",
     "react-syntax-highlighter": "^16.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import Layout from './components/Layout';
 import ListPage from './pages/list';
 import DetailPage from './pages/detail';
 import WritePage from './pages/write';
+import EditPage from './pages/edit';
+import GlobalToaster from './components/GlobalToaster';
 
 const router = createBrowserRouter([
   {
@@ -21,10 +23,19 @@ const router = createBrowserRouter([
         path: 'write',
         element: <WritePage />,
       },
+      {
+        path: 'edit',
+        element: <EditPage />,
+      },
     ],
   },
 ]);
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <GlobalToaster />
+      <RouterProvider router={router} />
+    </>
+  );
 }

--- a/src/apis/githubIssue.api.ts
+++ b/src/apis/githubIssue.api.ts
@@ -1,4 +1,9 @@
 import { createClient } from '../utils/fetchClient';
+import {
+  GitHubIssueResponse,
+  CreateEpisodeRequest,
+  UpdateEpisodeRequest,
+} from '../types/github';
 
 const baseUrl = process.env.GITHUB_BASE_URL;
 const token = process.env.GITHUB_TOKEN;
@@ -14,10 +19,9 @@ const githubClient = createClient({
   },
 });
 
-//TODO:: any 말고 interface 정의하기
 export const githubService = {
-  async getEpisodeList() {
-    const { data } = await githubClient.get(
+  async getEpisodeList(): Promise<GitHubIssueResponse[]> {
+    const { data } = await githubClient.get<GitHubIssueResponse[]>(
       `/repos/${owner}/${repoName}/issues`,
       {
         params: {
@@ -29,36 +33,47 @@ export const githubService = {
       },
     );
 
-    return data.filter((issue: any) => !issue.pull_request);
+    return data.filter((issue) => !issue.pull_request);
   },
-  async getEpisodeDetail(issueNumber: number) {
-    const { data } = await githubClient.get(
+  async getEpisodeDetail(issueNumber: number): Promise<GitHubIssueResponse> {
+    const { data } = await githubClient.get<GitHubIssueResponse>(
       `/repos/${owner}/${repoName}/issues/${issueNumber}`,
     );
     return data;
   },
-  async createEpisode(title: string, content: string) {
-    const { data } = await githubClient.post(
+  async createEpisode(
+    title: string,
+    content: string,
+  ): Promise<GitHubIssueResponse> {
+    const body: CreateEpisodeRequest = {
+      title,
+      body: content,
+      labels: ['novel-episode'],
+    };
+
+    const { data } = await githubClient.post<GitHubIssueResponse>(
       `/repos/${owner}/${repoName}/issues`,
-      {
-        title,
-        body: content,
-        labels: ['novel-episode'], // 라벨로 데이터 구분 가능
-      },
+      body,
     );
     return data;
   },
-  async updateEpisode(issueNumber: number, title: string, content: string) {
-    const { data } = await githubClient.patch(
+  async updateEpisode(
+    issueNumber: number,
+    title: string,
+    content: string,
+  ): Promise<GitHubIssueResponse> {
+    const body: UpdateEpisodeRequest = {
+      title,
+      body: content,
+    };
+
+    const { data } = await githubClient.patch<GitHubIssueResponse>(
       `/repos/${owner}/${repoName}/issues/${issueNumber}`,
-      {
-        title,
-        body: content,
-      },
+      body,
     );
     return data;
   },
-  async deleteEpisode(issueNumber: number) {
+  async deleteEpisode(issueNumber: number): Promise<void> {
     await githubClient.patch(
       `/repos/${owner}/${repoName}/issues/${issueNumber}`,
       {

--- a/src/components/GlobalToaster.tsx
+++ b/src/components/GlobalToaster.tsx
@@ -1,0 +1,34 @@
+import { Toaster } from 'react-hot-toast';
+
+const GlobalToaster = () => {
+  return (
+    <Toaster
+      position="top-center"
+      reverseOrder={false}
+      toastOptions={{
+        className: 'font-sans text-md text-bold',
+        duration: 3000,
+        style: {
+          background: '#333',
+          color: '#fff',
+          borderRadius: '8px',
+          padding: '12px 20px',
+        },
+        success: {
+          iconTheme: {
+            primary: '#3B82F6',
+            secondary: '#fff',
+          },
+        },
+        error: {
+          iconTheme: {
+            primary: '#EF4444',
+            secondary: '#fff',
+          },
+        },
+      }}
+    />
+  );
+};
+
+export default GlobalToaster;

--- a/src/components/WriteForm.tsx
+++ b/src/components/WriteForm.tsx
@@ -25,7 +25,6 @@ export function WriteForm({
   initialValues = { title: '', content: '' },
   onSubmit,
   isPending,
-  errorMessage,
   submitLabel = '작성 완료',
 }: WriteFormProps) {
   const { values, errors, handleChange, handleSubmit, reset } =
@@ -33,7 +32,6 @@ export function WriteForm({
 
   const submit = handleSubmit((values) => {
     onSubmit(values);
-    reset();
   });
 
   return (

--- a/src/components/WriteForm.tsx
+++ b/src/components/WriteForm.tsx
@@ -1,0 +1,104 @@
+import { useForm } from '../hooks/useForm';
+
+export interface EpisodeFormValues {
+  [key: string]: string;
+  title: string;
+  content: string;
+}
+
+interface WriteFormProps {
+  onSubmit: (values: EpisodeFormValues) => void;
+  isPending: boolean;
+  errorMessage?: string;
+  submitLabel?: string;
+  initialValues?: EpisodeFormValues;
+}
+
+const validators = {
+  title: (v: string) => (!v.trim() ? '제목을 입력해주세요.' : undefined),
+  content: (v: string) => (!v.trim() ? '내용을 입력해주세요.' : undefined),
+};
+
+const initialValues: EpisodeFormValues = { title: '', content: '' };
+
+export function WriteForm({
+  initialValues = { title: '', content: '' },
+  onSubmit,
+  isPending,
+  errorMessage,
+  submitLabel = '작성 완료',
+}: WriteFormProps) {
+  const { values, errors, handleChange, handleSubmit, reset } =
+    useForm<EpisodeFormValues>(initialValues, validators);
+
+  const submit = handleSubmit((values) => {
+    onSubmit(values);
+    reset();
+  });
+
+  return (
+    <form onSubmit={submit} className="max-w-3xl mx-auto">
+      <div className="flex justify-end items-center gap-4 mb-4">
+        {isPending && (
+          <span className="text-sm text-gray-400 font-serif animate-pulse">
+            저장 중...
+          </span>
+        )}
+        <button
+          type="submit"
+          disabled={isPending}
+          className={`
+            px-6 py-2 rounded-md font-sans text-sm transition-all duration-200 text-md font-bold 
+            ${
+              isPending
+                ? 'bg-gray-100 text-gray-200 cursor-not-allowed'
+                : ' bg-blue-600 text-white cursor-pointer hover:bg-blue-800'
+            }
+          `}
+        >
+          {submitLabel}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-8">
+        <section className="flex flex-col gap-3">
+          <label className="text-md font-bold text-gray-500 uppercase tracking-wider ml-1">
+            제목
+          </label>
+          <div className="group">
+            <input
+              type="text"
+              name="title"
+              value={values.title}
+              onChange={handleChange}
+              placeholder="제목을 입력하세요"
+              className="w-full bg-white border border-gray-100 rounded-lg text-lg md:text-xl *:text-gray-900 placeholder-gray-200 focus:ring-1 focus:ring-blue-100 focus:border-blue-300 px-6 py-4 transition-all shadow-sm"
+            />
+            {errors.title && (
+              <p className="mt-2 text-sm text-red-500 font-sans font-medium flex items-center gap-1">
+                *{errors.title}
+              </p>
+            )}
+          </div>
+        </section>
+        <section className="flex flex-col gap-3">
+          <label className="text-md font-bold text-gray-500 uppercase tracking-wider ml-1">
+            내용
+          </label>
+          <textarea
+            name="content"
+            value={values.content}
+            onChange={handleChange}
+            placeholder="내용을 입력하세요"
+            className="w-full min-h-[600px] bg-white border border-gray-100 rounded-lg text-lg md:text-xl leading-loose text-gray-800 placeholder-gray-200 focus:ring-1 focus:ring-blue-100 focus:border-blue-300 px-6 py-4 resize-none transition-all shadow-sm"
+          />
+          {errors.content && (
+            <p className="mt-4 text-sm text-red-500 font-sans font-medium flex items-center gap-1">
+              *{errors.content}
+            </p>
+          )}
+        </section>
+      </div>
+    </form>
+  );
+}

--- a/src/components/icons/ArrowUpIcon.tsx
+++ b/src/components/icons/ArrowUpIcon.tsx
@@ -1,0 +1,19 @@
+export const ArrowUpIcon = ({
+  className = 'w-6 h-6',
+}: {
+  className?: string;
+}) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M5 11l7-7 7 7M12 4v16"
+    />
+  </svg>
+);

--- a/src/components/icons/ChevronLeftIcon.tsx
+++ b/src/components/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,19 @@
+export const ChevronLeftIcon = ({
+  className = 'w-4 h-4',
+}: {
+  className?: string;
+}) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 19l-7-7 7-7"
+    />
+  </svg>
+);

--- a/src/components/icons/EditIcon.tsx
+++ b/src/components/icons/EditIcon.tsx
@@ -1,0 +1,15 @@
+export const EditIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+    />
+  </svg>
+);

--- a/src/components/icons/TrashIcon.tsx
+++ b/src/components/icons/TrashIcon.tsx
@@ -1,0 +1,19 @@
+export const TrashIcon = ({
+  className = 'w-4 h-4',
+}: {
+  className?: string;
+}) => (
+  <svg
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+    />
+  </svg>
+);

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,0 +1,4 @@
+export * from './ChevronLeftIcon';
+export * from './TrashIcon';
+export * from './EditIcon';
+export * from './ArrowUpIcon';

--- a/src/enums/error.ts
+++ b/src/enums/error.ts
@@ -1,0 +1,20 @@
+import { ErrorCode } from '../types/error';
+
+export const ERROR_CODE_MAP: Record<number, ErrorCode> = {
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  422: 'VALIDATION_ERROR',
+  429: 'RATE_LIMITED',
+} as const;
+
+export const ERROR_MESSAGES: Record<string, string> = {
+  UNAUTHORIZED: '인증이 필요합니다. GitHub 토큰을 확인해주세요.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+  NOT_FOUND: '요청한 리소스를 찾을 수 없습니다.',
+  RATE_LIMITED: 'API 호출 한도를 초과했습니다. 잠시 후 다시 시도해주세요.',
+  VALIDATION_ERROR: '입력값을 확인해주세요.',
+  SERVER_ERROR: 'GitHub 서버 오류입니다. 잠시 후 다시 시도해주세요.',
+  NETWORK_ERROR: '네트워크 연결을 확인해주세요.',
+  UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',
+};

--- a/src/hooks/useCreateEpisode.ts
+++ b/src/hooks/useCreateEpisode.ts
@@ -1,0 +1,32 @@
+import { GitHubIssueResponse } from '../types/github';
+import { githubService } from '../apis/githubIssue.api';
+import { useNavigate } from 'react-router-dom';
+import { useOptimisticMutation } from './useOptimisticMutation';
+import toast from 'react-hot-toast';
+
+export function useCreateEpisode() {
+  const navigate = useNavigate();
+
+  return useOptimisticMutation<
+    GitHubIssueResponse[],
+    { title: string; content: string }
+  >({
+    queryKey: ['episodes'],
+    mutationFn: ({ title, content }) =>
+      githubService.createEpisode(title, content),
+    updater: (old = [], newEpisode) => [
+      ...old,
+      {
+        id: Date.now(),
+        number: Date.now(),
+        title: newEpisode.title,
+        created_at: new Date().toISOString(),
+        _isOptimistic: true,
+      } as GitHubIssueResponse,
+    ],
+    onSuccess: () => {
+      toast.success('원고가 등록되었습니다.');
+      navigate('/');
+    },
+  });
+}

--- a/src/hooks/useCreateEpisode.ts
+++ b/src/hooks/useCreateEpisode.ts
@@ -3,9 +3,34 @@ import { githubService } from '../apis/githubIssue.api';
 import { useNavigate } from 'react-router-dom';
 import { useOptimisticMutation } from './useOptimisticMutation';
 import toast from 'react-hot-toast';
+import { useQueryClient } from '@tanstack/react-query';
 
 export function useCreateEpisode() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // const syncAfterCreate = async (createdNumber: number) => {
+  //   for (const delay of [3000, 3000, 5000]) {
+  //     await new Promise((r) => setTimeout(r, delay));
+
+  //     try {
+  //       const episode = await githubService.getEpisodeDetail(createdNumber);
+
+  //       if (episode) {
+  //         queryClient.setQueryData<GitHubIssueResponse[]>(
+  //           ['episodes'],
+  //           (old = []) =>
+  //             old.map((ep) =>
+  //               ep.number === createdNumber
+  //                 ? { ...episode, _isOptimistic: false }
+  //                 : ep,
+  //             ),
+  //         );
+  //         return;
+  //       }
+  //     } catch {}
+  //   }
+  // };
 
   return useOptimisticMutation<
     GitHubIssueResponse[],
@@ -14,19 +39,26 @@ export function useCreateEpisode() {
     queryKey: ['episodes'],
     mutationFn: ({ title, content }) =>
       githubService.createEpisode(title, content),
-    updater: (old = [], newEpisode) => [
-      ...old,
-      {
-        id: Date.now(),
-        number: Date.now(),
-        title: newEpisode.title,
-        created_at: new Date().toISOString(),
-        _isOptimistic: true,
-      } as GitHubIssueResponse,
-    ],
-    onSuccess: () => {
+    onSuccess: (createdEpisode: GitHubIssueResponse) => {
       toast.success('원고가 등록되었습니다.');
+
+      queryClient.setQueryData<GitHubIssueResponse[]>(
+        ['episodes'],
+        (old = []) => [
+          ...old,
+          {
+            ...createdEpisode,
+            _isOptimistic: true,
+          } as GitHubIssueResponse,
+        ],
+      );
+
       navigate('/');
+
+      // syncAfterCreate(createdEpisode.number);
+    },
+    onError: () => {
+      toast.error('등록에 실패했습니다.');
     },
   });
 }

--- a/src/hooks/useCreateEpisode.tsx
+++ b/src/hooks/useCreateEpisode.tsx
@@ -4,33 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import { useOptimisticMutation } from './useOptimisticMutation';
 import toast from 'react-hot-toast';
 import { useQueryClient } from '@tanstack/react-query';
+import { useSyncAfterMutation } from './useSyncAfterMutation';
 
 export function useCreateEpisode() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  // const syncAfterCreate = async (createdNumber: number) => {
-  //   for (const delay of [3000, 3000, 5000]) {
-  //     await new Promise((r) => setTimeout(r, delay));
-
-  //     try {
-  //       const episode = await githubService.getEpisodeDetail(createdNumber);
-
-  //       if (episode) {
-  //         queryClient.setQueryData<GitHubIssueResponse[]>(
-  //           ['episodes'],
-  //           (old = []) =>
-  //             old.map((ep) =>
-  //               ep.number === createdNumber
-  //                 ? { ...episode, _isOptimistic: false }
-  //                 : ep,
-  //             ),
-  //         );
-  //         return;
-  //       }
-  //     } catch {}
-  //   }
-  // };
+  const { sync } = useSyncAfterMutation();
 
   return useOptimisticMutation<
     GitHubIssueResponse[],
@@ -55,7 +34,7 @@ export function useCreateEpisode() {
 
       navigate('/');
 
-      // syncAfterCreate(createdEpisode.number);
+      sync((data) => data.some((ep) => ep.number === createdEpisode.number));
     },
     onError: () => {
       toast.error('등록에 실패했습니다.');

--- a/src/hooks/useDeleteEpisode.ts
+++ b/src/hooks/useDeleteEpisode.ts
@@ -1,0 +1,23 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { githubService } from '../apis/githubIssue.api';
+import { GitHubIssueResponse } from '../types/github';
+import { useOptimisticMutation } from './useOptimisticMutation';
+import toast from 'react-hot-toast';
+
+export function useDeleteEpisode() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  return useOptimisticMutation<GitHubIssueResponse[], number>({
+    queryKey: ['episodes'], // 목록 쿼리 키
+    mutationFn: (issueNumber) => githubService.deleteEpisode(issueNumber),
+    updater: (old = [], deleteId) => old.filter((ep) => ep.number !== deleteId),
+    onSuccess: () => {
+      toast.error('원고가 삭제되었습니다.');
+      // 상세 페이지 정보는 더 이상 유효하지 않으므로 캐시 삭제
+      queryClient.removeQueries({ queryKey: ['episode'] });
+      navigate('/');
+    },
+  });
+}

--- a/src/hooks/useDeleteEpisode.tsx
+++ b/src/hooks/useDeleteEpisode.tsx
@@ -4,20 +4,24 @@ import { githubService } from '../apis/githubIssue.api';
 import { GitHubIssueResponse } from '../types/github';
 import { useOptimisticMutation } from './useOptimisticMutation';
 import toast from 'react-hot-toast';
+import { useSyncAfterMutation } from './useSyncAfterMutation';
 
 export function useDeleteEpisode() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { sync } = useSyncAfterMutation();
 
   return useOptimisticMutation<GitHubIssueResponse[], number>({
     queryKey: ['episodes'], // 목록 쿼리 키
     mutationFn: (issueNumber) => githubService.deleteEpisode(issueNumber),
     updater: (old = [], deleteId) => old.filter((ep) => ep.number !== deleteId),
-    onSuccess: () => {
+    onSuccess: (_, deletedId) => {
       toast.error('원고가 삭제되었습니다.');
-      // 상세 페이지 정보는 더 이상 유효하지 않으므로 캐시 삭제
+
       queryClient.removeQueries({ queryKey: ['episode'] });
       navigate('/');
+
+      sync((data) => !data.some((ep) => ep.number === deletedId));
     },
   });
 }

--- a/src/hooks/useForm.tsx
+++ b/src/hooks/useForm.tsx
@@ -1,0 +1,83 @@
+// src/hooks/useForm.ts
+import { useState, useCallback, ChangeEvent } from 'react';
+
+type FieldValues = Record<string, string>;
+
+type FieldErrors<T extends FieldValues> = Partial<Record<keyof T, string>>;
+
+type Validators<T extends FieldValues> = Partial<
+  Record<keyof T, (value: string) => string | undefined>
+>;
+
+interface UseFormReturn<T extends FieldValues> {
+  values: T;
+  errors: FieldErrors<T>;
+  isValid: boolean;
+  handleChange: (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+  handleSubmit: (onSubmit: (values: T) => void) => (e: React.FormEvent) => void;
+  reset: () => void;
+}
+
+export function useForm<T extends Record<keyof T, string>>(
+  initialValues: T,
+  validators?: Validators<T>,
+): UseFormReturn<T> {
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<FieldErrors<T>>({});
+
+  const validate = useCallback(
+    (name: keyof T, value: string): string | undefined => {
+      return validators?.[name]?.(value);
+    },
+    [validators],
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = e.target;
+      setValues((prev) => ({ ...prev, [name]: value }));
+
+      // 입력 중 실시간 에러 해제
+      const error = validate(name as keyof T, value);
+      setErrors((prev) => ({ ...prev, [name]: error }));
+    },
+    [validate],
+  );
+
+  const handleSubmit = useCallback(
+    (onSubmit: (values: T) => void) => (e: React.FormEvent) => {
+      e.preventDefault();
+
+      // 전체 필드 유효성 검사
+      const newErrors: FieldErrors<T> = {};
+      let hasError = false;
+
+      (Object.keys(values) as (keyof T)[]).forEach((key) => {
+        const error = validate(key, values[key]);
+        if (error) {
+          newErrors[key] = error;
+          hasError = true;
+        }
+      });
+
+      if (hasError) {
+        setErrors(newErrors);
+        return;
+      }
+
+      onSubmit(values);
+    },
+    [values, validate],
+  );
+
+  const reset = useCallback(() => {
+    setValues(initialValues);
+    setErrors({});
+  }, [initialValues]);
+
+  const isValid = Object.values(errors).every((e) => !e);
+
+  return { values, errors, isValid, handleChange, handleSubmit, reset };
+}

--- a/src/hooks/useOptimisticMutation.ts
+++ b/src/hooks/useOptimisticMutation.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query';
+
+interface OptimisticConfig<TData, TVariables, TContext> {
+  queryKey: QueryKey;
+  updater: (oldData: TData | undefined, variables: TVariables) => TData;
+  mutationFn: (variables: TVariables) => Promise<any>;
+  onSuccess?: (data: any, variables: TVariables) => void;
+}
+
+export function useOptimisticMutation<TData, TVariables>({
+  queryKey,
+  updater,
+  mutationFn,
+  onSuccess,
+}: OptimisticConfig<TData, TVariables, { previousData: TData | undefined }>) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn,
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousData = queryClient.getQueryData<TData>(queryKey);
+
+      queryClient.setQueryData<TData>(queryKey, (old) =>
+        updater(old, variables),
+      );
+
+      return { previousData };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(queryKey, context.previousData);
+      }
+    },
+    onSuccess: (data, variables) => {
+      if (onSuccess) onSuccess(data, variables);
+    },
+    //TODO:: 할지말지....의미가 있을지 모르겠는
+    onSettled: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+}

--- a/src/hooks/useOptimisticMutation.ts
+++ b/src/hooks/useOptimisticMutation.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query';
 
 interface OptimisticConfig<TData, TVariables, TContext> {
   queryKey: QueryKey;
-  updater: (oldData: TData | undefined, variables: TVariables) => TData;
+  updater?: (oldData: TData | undefined, variables: TVariables) => TData;
   mutationFn: (variables: TVariables) => Promise<any>;
   onSuccess?: (data: any, variables: TVariables) => void;
+  onError?: (error: unknown) => void;
+  confirmFn?: () => Promise<boolean>;
 }
 
 export function useOptimisticMutation<TData, TVariables>({
@@ -12,6 +14,7 @@ export function useOptimisticMutation<TData, TVariables>({
   updater,
   mutationFn,
   onSuccess,
+  onError,
 }: OptimisticConfig<TData, TVariables, { previousData: TData | undefined }>) {
   const queryClient = useQueryClient();
 
@@ -23,23 +26,19 @@ export function useOptimisticMutation<TData, TVariables>({
       const previousData = queryClient.getQueryData<TData>(queryKey);
 
       queryClient.setQueryData<TData>(queryKey, (old) =>
-        updater(old, variables),
+        updater?.(old, variables),
       );
 
       return { previousData };
     },
-    onError: (err, variables, context) => {
+    onError: (error, variables, context) => {
       if (context?.previousData) {
         queryClient.setQueryData(queryKey, context.previousData);
       }
+      onError?.(error);
     },
     onSuccess: (data, variables) => {
-      if (onSuccess) onSuccess(data, variables);
-    },
-    //TODO:: 할지말지....의미가 있을지 모르겠는
-    onSettled: async () => {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      queryClient.invalidateQueries({ queryKey });
+      onSuccess?.(data, variables);
     },
   });
 }

--- a/src/hooks/useSyncAfterMutation.tsx
+++ b/src/hooks/useSyncAfterMutation.tsx
@@ -1,0 +1,35 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { GitHubIssueResponse } from '../types/github';
+import { githubService } from '../apis/githubIssue.api';
+
+/**
+ * polling을 통해 낙관적 데이터와 실제 데이터의 sync를 맞춥니다.
+ */
+export function useSyncAfterMutation() {
+  const queryClient = useQueryClient();
+
+  const sync = useCallback(
+    (checkFn: (data: GitHubIssueResponse[]) => boolean) => {
+      let attempts = 0;
+      const MAX_ATTEMPTS = 10;
+
+      const poll = async () => {
+        attempts++;
+
+        const freshList = await githubService.getEpisodeList();
+
+        if (checkFn(freshList)) {
+          queryClient.setQueryData(['episodes'], freshList);
+        } else if (attempts < MAX_ATTEMPTS) {
+          setTimeout(poll, 3000 * attempts);
+        }
+      };
+
+      setTimeout(poll, 5000);
+    },
+    [queryClient],
+  );
+
+  return { sync };
+}

--- a/src/hooks/useUpdateEpisode.tsx
+++ b/src/hooks/useUpdateEpisode.tsx
@@ -7,6 +7,38 @@ import toast from 'react-hot-toast';
 
 export function useUpdateEpisode() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // 수정 후 API 반영 여부를 체크하고 캐시를 최신화하는 함수
+  // const syncAfterUpdate = async (id: number) => {
+  //   // 생성과 마찬가지로 점진적 딜레이를 주며 확인
+  //   for (const delay of [3000, 3000, 5000]) {
+  //     await new Promise((r) => setTimeout(r, delay));
+
+  //     try {
+  //       const updatedEpisode = await githubService.getEpisodeDetail(id);
+
+  //       // API 응답 데이터가 우리가 보낸 최신 데이터인지 확인 (필요시 상세 조건 추가)
+  //       if (updatedEpisode) {
+  //         queryClient.setQueryData<GitHubIssueResponse[]>(
+  //           ['episodes'],
+  //           (old = []) =>
+  //             old.map((ep) =>
+  //               ep.number === id
+  //                 ? { ...updatedEpisode, _isOptimistic: false }
+  //                 : ep,
+  //             ),
+  //         );
+
+  //         // 상세 페이지 쿼리도 같이 업데이트 해주면 좋습니다.
+  //         queryClient.setQueryData(['episode', id], updatedEpisode);
+  //         return;
+  //       }
+  //     } catch (e) {
+  //       console.error('Sync failed', e);
+  //     }
+  //   }
+  // };
 
   return useOptimisticMutation<
     GitHubIssueResponse[],
@@ -16,17 +48,28 @@ export function useUpdateEpisode() {
     mutationFn: ({ id, title, content }) =>
       githubService.updateEpisode(id, title, content),
 
-    // 낙관적 업데이트: 리스트에서 해당 ID의 에피소드만 교체
-    updater: (old = [], { id, title, content }) =>
-      old.map((ep) =>
-        ep.number === id
-          ? { ...ep, title, body: content, _isOptimistic: true }
-          : ep,
-      ),
-
-    onSuccess: (_, { id }) => {
+    // 1. updater는 비워두거나 즉각적인 UI 반응용으로만 사용 (선택 사항)
+    // 2. onSuccess에서 서버 응답을 기반으로 확실하게 처리
+    onSuccess: (updatedEpisode: GitHubIssueResponse, { id }) => {
       toast.success('원고가 수정되었습니다.');
+
+      // 목록 캐시 수동 업데이트
+      queryClient.setQueryData<GitHubIssueResponse[]>(
+        ['episodes'],
+        (old = []) =>
+          old.map((ep) =>
+            ep.number === id ? { ...updatedEpisode, _isOptimistic: true } : ep,
+          ),
+      );
+
+      // 상세 페이지로 즉시 이동
       navigate(`/episode/${id}`);
+
+      // 백그라운드에서 동기화 시작
+      // syncAfterUpdate(id);
+    },
+    onError: () => {
+      toast.error('수정에 실패했습니다.');
     },
   });
 }

--- a/src/hooks/useUpdateEpisode.tsx
+++ b/src/hooks/useUpdateEpisode.tsx
@@ -4,41 +4,12 @@ import { useOptimisticMutation } from './useOptimisticMutation';
 import { GitHubIssueResponse } from '../types/github';
 import { githubService } from '../apis/githubIssue.api';
 import toast from 'react-hot-toast';
+import { useSyncAfterMutation } from './useSyncAfterMutation';
 
 export function useUpdateEpisode() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  // 수정 후 API 반영 여부를 체크하고 캐시를 최신화하는 함수
-  // const syncAfterUpdate = async (id: number) => {
-  //   // 생성과 마찬가지로 점진적 딜레이를 주며 확인
-  //   for (const delay of [3000, 3000, 5000]) {
-  //     await new Promise((r) => setTimeout(r, delay));
-
-  //     try {
-  //       const updatedEpisode = await githubService.getEpisodeDetail(id);
-
-  //       // API 응답 데이터가 우리가 보낸 최신 데이터인지 확인 (필요시 상세 조건 추가)
-  //       if (updatedEpisode) {
-  //         queryClient.setQueryData<GitHubIssueResponse[]>(
-  //           ['episodes'],
-  //           (old = []) =>
-  //             old.map((ep) =>
-  //               ep.number === id
-  //                 ? { ...updatedEpisode, _isOptimistic: false }
-  //                 : ep,
-  //             ),
-  //         );
-
-  //         // 상세 페이지 쿼리도 같이 업데이트 해주면 좋습니다.
-  //         queryClient.setQueryData(['episode', id], updatedEpisode);
-  //         return;
-  //       }
-  //     } catch (e) {
-  //       console.error('Sync failed', e);
-  //     }
-  //   }
-  // };
+  const { sync } = useSyncAfterMutation();
 
   return useOptimisticMutation<
     GitHubIssueResponse[],
@@ -48,8 +19,6 @@ export function useUpdateEpisode() {
     mutationFn: ({ id, title, content }) =>
       githubService.updateEpisode(id, title, content),
 
-    // 1. updater는 비워두거나 즉각적인 UI 반응용으로만 사용 (선택 사항)
-    // 2. onSuccess에서 서버 응답을 기반으로 확실하게 처리
     onSuccess: (updatedEpisode: GitHubIssueResponse, { id }) => {
       toast.success('원고가 수정되었습니다.');
 
@@ -62,11 +31,18 @@ export function useUpdateEpisode() {
           ),
       );
 
+      queryClient.setQueryData<GitHubIssueResponse>(['episode', String(id)], {
+        ...updatedEpisode,
+        _isOptimistic: true,
+      });
+
       // 상세 페이지로 즉시 이동
       navigate(`/episode/${id}`);
 
-      // 백그라운드에서 동기화 시작
-      // syncAfterUpdate(id);
+      sync((freshData) => {
+        const target = freshData.find((ep) => ep.number === id);
+        return target?.updated_at === updatedEpisode.updated_at;
+      });
     },
     onError: () => {
       toast.error('수정에 실패했습니다.');

--- a/src/hooks/useUpdateEpisode.tsx
+++ b/src/hooks/useUpdateEpisode.tsx
@@ -1,0 +1,32 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useOptimisticMutation } from './useOptimisticMutation';
+import { GitHubIssueResponse } from '../types/github';
+import { githubService } from '../apis/githubIssue.api';
+import toast from 'react-hot-toast';
+
+export function useUpdateEpisode() {
+  const navigate = useNavigate();
+
+  return useOptimisticMutation<
+    GitHubIssueResponse[],
+    { id: number; title: string; content: string }
+  >({
+    queryKey: ['episodes'],
+    mutationFn: ({ id, title, content }) =>
+      githubService.updateEpisode(id, title, content),
+
+    // 낙관적 업데이트: 리스트에서 해당 ID의 에피소드만 교체
+    updater: (old = [], { id, title, content }) =>
+      old.map((ep) =>
+        ep.number === id
+          ? { ...ep, title, body: content, _isOptimistic: true }
+          : ep,
+      ),
+
+    onSuccess: (_, { id }) => {
+      toast.success('원고가 수정되었습니다.');
+      navigate(`/episode/${id}`);
+    },
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,29 +1,23 @@
-@import "tailwindcss";
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css");
+@import 'tailwindcss';
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css');
 
 :root {
-    --my-sans: "Pretendard Variable", "Pretendard", -apple-system, sans-serif;
-    --my-ivory: #f4f1ea;
-  }
+  --my-sans: 'Pretendard Variable', 'Pretendard', -apple-system, sans-serif;
+  --my-ivory: #f4f1ea;
+}
 
 @theme {
-    /* 1. 커스텀 컬러 정의 (이제 bg-ivory, text-ivory 사용 가능) */
-    --color-ivory: #f4f1ea;
-    
-    /* 2. 소설 전용 포인트 컬러 (예: 딥 그린) */
-    --color-novel-dark: #2c3e50;
-  
-    /* 3. 기본 폰트 시스템 교체 (Pretendard) */
-    --font-sans: var(--my-sans);
-    --color-ivory: var(--my-ivory);
-  }
-  
+  --color-novel-dark: #2c3e50;
+  --font-sans: var(--my-sans);
+  --color-ivory: var(--my-ivory);
+}
 
-  @layer base {
-    html, body {
-        font-family: var(--font-sans);
-        @apply bg-ivory text-gray-900;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
+@layer base {
+  html,
+  body {
+    font-family: var(--font-sans);
+    @apply bg-ivory text-gray-900;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
+}

--- a/src/pages/detail.tsx
+++ b/src/pages/detail.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { githubService } from '../apis/githubIssue.api';
 import EpisodeViewer from '../components/EpisodeViewer';
 import ProgressBar from '../components/ProgressBar';
@@ -19,6 +19,14 @@ const DetailPage = () => {
   const [fontSize, setFontSize] = useState(18);
   const [showTopButton, setShowTopButton] = useState(false);
   const { mutate: deleteEpisode, isPending: isDeleting } = useDeleteEpisode();
+  const queryClient = useQueryClient();
+
+  const isOptimistic =
+    queryClient
+      .getQueryData<GitHubIssueResponse[]>(['episodes'])
+      ?.find((ep) => ep.number === Number(id))?._isOptimistic ?? false;
+
+  console.log({ isOptimistic });
 
   useEffect(() => {
     const handleScroll = () => {
@@ -37,9 +45,14 @@ const DetailPage = () => {
   const { data: episode, isLoading } = useQuery<GitHubIssueResponse>({
     queryKey: ['episode', id],
     queryFn: () => githubService.getEpisodeDetail(Number(id)),
-    enabled: !!id,
+    enabled: !!id && !isOptimistic,
+    initialData: isOptimistic
+      ? queryClient
+          .getQueryData<GitHubIssueResponse[]>(['episodes'])
+          ?.find((ep) => ep.number === Number(id))
+      : undefined,
   });
-
+  console.log({ episode });
   const handleDelete = () => {
     if (!id || isDeleting) return;
 
@@ -90,33 +103,39 @@ const DetailPage = () => {
           </div>
         </div>
       </div>
-      <div className="flex justify-end items-center gap-4 mb-6">
-        <button
-          onClick={handleDelete}
-          disabled={isDeleting}
-          className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
-            isDeleting
-              ? 'text-gray-300 cursor-not-allowed'
-              : 'text-gray-600 hover:text-red-500'
-          }`}
-        >
-          <TrashIcon />
-          {isDeleting ? '삭제 중...' : '삭제'}
-        </button>
-        <span className="text-gray-300">|</span>
-        <button
-          onClick={() => navigate(`/edit?id=${id}`)}
-          disabled={isDeleting}
-          className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
-            isDeleting
-              ? 'text-gray-300 cursor-not-allowed'
-              : 'text-gray-600 hover:text-blue-600'
-          }`}
-        >
-          <EditIcon />
-          수정
-        </button>
-      </div>
+      {isOptimistic ? (
+        <div className="mb-4 px-4 py-2 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-700">
+          서버에 반영 중이에요. 수정/삭제는 잠시 후 가능해요.
+        </div>
+      ) : (
+        <div className="flex justify-end items-center gap-4 mb-6">
+          <button
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
+              isDeleting
+                ? 'text-gray-300 cursor-not-allowed'
+                : 'text-gray-600 hover:text-red-500'
+            }`}
+          >
+            <TrashIcon />
+            {isDeleting ? '삭제 중...' : '삭제'}
+          </button>
+          <span className="text-gray-300">|</span>
+          <button
+            onClick={() => navigate(`/edit?id=${id}`)}
+            disabled={isDeleting}
+            className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
+              isDeleting
+                ? 'text-gray-300 cursor-not-allowed'
+                : 'text-gray-600 hover:text-blue-600'
+            }`}
+          >
+            <EditIcon />
+            수정
+          </button>
+        </div>
+      )}
       {/* 헤더 */}
       <header className="mb-12 text-center">
         <h1

--- a/src/pages/detail.tsx
+++ b/src/pages/detail.tsx
@@ -26,8 +26,6 @@ const DetailPage = () => {
       .getQueryData<GitHubIssueResponse[]>(['episodes'])
       ?.find((ep) => ep.number === Number(id))?._isOptimistic ?? false;
 
-  console.log({ isOptimistic });
-
   useEffect(() => {
     const handleScroll = () => {
       // 300px 이상 스크롤 시 버튼 표시
@@ -45,14 +43,9 @@ const DetailPage = () => {
   const { data: episode, isLoading } = useQuery<GitHubIssueResponse>({
     queryKey: ['episode', id],
     queryFn: () => githubService.getEpisodeDetail(Number(id)),
-    enabled: !!id && !isOptimistic,
-    initialData: isOptimistic
-      ? queryClient
-          .getQueryData<GitHubIssueResponse[]>(['episodes'])
-          ?.find((ep) => ep.number === Number(id))
-      : undefined,
+    enabled: !!id,
   });
-  console.log({ episode });
+
   const handleDelete = () => {
     if (!id || isDeleting) return;
 

--- a/src/pages/detail.tsx
+++ b/src/pages/detail.tsx
@@ -4,17 +4,21 @@ import { githubService } from '../apis/githubIssue.api';
 import EpisodeViewer from '../components/EpisodeViewer';
 import ProgressBar from '../components/ProgressBar';
 import { useEffect, useState } from 'react';
-interface EpisodeDetail {
-  title: string;
-  body: string;
-  created_at: string;
-}
+import { GitHubIssueResponse } from '../types/github';
+import { useDeleteEpisode } from '../hooks/useDeleteEpisode';
+import {
+  ChevronLeftIcon,
+  TrashIcon,
+  EditIcon,
+  ArrowUpIcon,
+} from '../components/icons';
 
 const DetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const [fontSize, setFontSize] = useState(18);
   const [showTopButton, setShowTopButton] = useState(false);
+  const { mutate: deleteEpisode, isPending: isDeleting } = useDeleteEpisode();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -30,11 +34,19 @@ const DetailPage = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const { data: episode, isLoading } = useQuery<EpisodeDetail>({
+  const { data: episode, isLoading } = useQuery<GitHubIssueResponse>({
     queryKey: ['episode', id],
     queryFn: () => githubService.getEpisodeDetail(Number(id)),
     enabled: !!id,
   });
+
+  const handleDelete = () => {
+    if (!id || isDeleting) return;
+
+    if (window.confirm('이 원고를 삭제하시겠습니까?')) {
+      deleteEpisode(Number(id));
+    }
+  };
 
   if (isLoading)
     return (
@@ -47,26 +59,17 @@ const DetailPage = () => {
     <article className="max-w-2xl mx-auto px-4 relative overflow-x-hidden">
       <ProgressBar />
 
-      <div className="flex justify-between items-center mb-10 border-b pb-4">
-        <button
-          onClick={() => navigate('/')}
-          className="text-gray-500 hover:text-blue-600 flex items-center gap-1 transition-colors"
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+      <div className="flex justify-between items-center  border-b pb-4 mb-4">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigate('/')}
+            className="text-gray-500 hover:text-blue-600 flex items-center gap-1 transition-colors cursor-pointer"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
-          목록으로
-        </button>
+            <ChevronLeftIcon />
+            목록으로
+          </button>
+        </div>
+
         <div className="flex gap-4">
           <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-full shadow-inner">
             <button
@@ -87,7 +90,33 @@ const DetailPage = () => {
           </div>
         </div>
       </div>
-
+      <div className="flex justify-end items-center gap-4 mb-6">
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
+            isDeleting
+              ? 'text-gray-300 cursor-not-allowed'
+              : 'text-gray-600 hover:text-red-500'
+          }`}
+        >
+          <TrashIcon />
+          {isDeleting ? '삭제 중...' : '삭제'}
+        </button>
+        <span className="text-gray-300">|</span>
+        <button
+          onClick={() => navigate(`/edit?id=${id}`)}
+          disabled={isDeleting}
+          className={`cursor-pointer flex items-center gap-1 transition-colors text-sm ${
+            isDeleting
+              ? 'text-gray-300 cursor-not-allowed'
+              : 'text-gray-600 hover:text-blue-600'
+          }`}
+        >
+          <EditIcon />
+          수정
+        </button>
+      </div>
       {/* 헤더 */}
       <header className="mb-12 text-center">
         <h1
@@ -117,33 +146,16 @@ const DetailPage = () => {
       <div className="fixed bottom-8 left-0 w-full flex justify-center pointer-events-none z-50">
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className={`p-4 bg-gray-900 text-white rounded-full shadow-2xl transition-all duration-500 pointer-events-auto hover:bg-blue-600 active:scale-90 ${
+          className={`cursor-pointer p-4 bg-gray-900 text-white rounded-full shadow-2xl transition-all duration-500 pointer-events-auto hover:bg-blue-600 active:scale-90 ${
             showTopButton
               ? 'opacity-100 translate-y-0 scale-100'
               : 'opacity-0 translate-y-20 scale-50'
           }`}
           aria-label="Scroll to top"
         >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M5 11l7-7 7 7M12 4v16"
-            />
-          </svg>
+          <ArrowUpIcon />
         </button>
       </div>
-
-      {/* 하단 푸터 (버튼 제거 버전) */}
-      <footer className="mt-32 pb-20 border-t border-gray-100 text-center text-gray-300 text-xs font-mono">
-        © DEV_HANSU. ALL RIGHTS RESERVED.
-      </footer>
     </article>
   );
 };

--- a/src/pages/edit.tsx
+++ b/src/pages/edit.tsx
@@ -1,4 +1,3 @@
-// src/pages/EditPage.tsx
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { githubService } from '../apis/githubIssue.api';
@@ -10,20 +9,17 @@ export default function EditPage() {
   const [searchParams] = useSearchParams();
   const id = searchParams.get('id');
 
-  // 기존 데이터 불러오기 (폼의 initialValues로 사용)
   const { data: episode, isLoading } = useQuery<GitHubIssueResponse>({
     queryKey: ['episode', id],
     queryFn: () => githubService.getEpisodeDetail(Number(id)),
     enabled: !!id,
   });
 
-  // 수정 Mutation 훅
   const { mutate: updateEpisode, isPending: isUpdating } = useUpdateEpisode();
 
   const handleUpdate = (values: EpisodeFormValues) => {
     if (!id) return;
 
-    // 낙관적 업데이트가 포함된 수정 실행
     updateEpisode({
       id: Number(id),
       title: values.title,

--- a/src/pages/edit.tsx
+++ b/src/pages/edit.tsx
@@ -1,0 +1,50 @@
+// src/pages/EditPage.tsx
+import { useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { githubService } from '../apis/githubIssue.api';
+import { WriteForm, EpisodeFormValues } from '../components/WriteForm';
+import { useUpdateEpisode } from '../hooks/useUpdateEpisode';
+import { GitHubIssueResponse } from '../types/github';
+
+export default function EditPage() {
+  const [searchParams] = useSearchParams();
+  const id = searchParams.get('id');
+
+  // 기존 데이터 불러오기 (폼의 initialValues로 사용)
+  const { data: episode, isLoading } = useQuery<GitHubIssueResponse>({
+    queryKey: ['episode', id],
+    queryFn: () => githubService.getEpisodeDetail(Number(id)),
+    enabled: !!id,
+  });
+
+  // 수정 Mutation 훅
+  const { mutate: updateEpisode, isPending: isUpdating } = useUpdateEpisode();
+
+  const handleUpdate = (values: EpisodeFormValues) => {
+    if (!id) return;
+
+    // 낙관적 업데이트가 포함된 수정 실행
+    updateEpisode({
+      id: Number(id),
+      title: values.title,
+      content: values.content,
+    });
+  };
+
+  if (isLoading)
+    return <div className="py-20 text-center font-serif">원고 로드 중...</div>;
+
+  return (
+    <main className="max-w-4xl mx-auto px-4">
+      <WriteForm
+        initialValues={{
+          title: episode?.title || '',
+          content: episode?.body || '',
+        }}
+        onSubmit={handleUpdate}
+        isPending={isUpdating}
+        submitLabel="수정 완료"
+      />
+    </main>
+  );
+}

--- a/src/pages/list.tsx
+++ b/src/pages/list.tsx
@@ -33,9 +33,8 @@ const ListPage = () => {
           총 {episodes?.length || 0}화
         </span>
       </div>
-      {/* TODO:: any 타입 지정해주기 */}
       <div className="grid gap-4">
-        {episodes?.map((ep: any) => (
+        {episodes?.map((ep) => (
           <Link
             key={ep.number}
             to={`/episode/${ep.number}`}

--- a/src/pages/list.tsx
+++ b/src/pages/list.tsx
@@ -38,12 +38,21 @@ const ListPage = () => {
           <Link
             key={ep.number}
             to={`/episode/${ep.number}`}
-            className="group block p-6 bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-blue-300 transition-all"
+            className={`group block p-6 bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-blue-300 transition-all  ${
+              ep._isOptimistic
+                ? 'border-yellow-200 opacity-70'
+                : 'border-gray-200 hover:shadow-md hover:border-blue-300'
+            }`}
           >
             <div className="flex justify-between items-center">
               <div>
                 <h2 className="text-xl font-bold text-gray-800 group-hover:text-blue-600 transition-colors">
                   {ep.title}
+                  {ep._isOptimistic && (
+                    <span className="ml-2 text-xs font-normal text-yellow-500">
+                      반영 중...
+                    </span>
+                  )}
                 </h2>
                 <p className="text-gray-400 text-sm mt-2 font-light">
                   {new Date(ep.created_at).toLocaleDateString()} · 조회수{' '}

--- a/src/pages/write.tsx
+++ b/src/pages/write.tsx
@@ -1,12 +1,28 @@
-const WritePage = () => {
+import { WriteForm, EpisodeFormValues } from '../components/WriteForm';
+import { AppError } from '../types/error';
+import { ERROR_MESSAGES } from '../enums/error';
+import { useCreateEpisode } from '../hooks/useCreateEpisode';
+
+export default function WritePage() {
+  const { mutate, isPending, isError, error, reset } = useCreateEpisode();
+
+  const errorMessage =
+    isError && error instanceof AppError
+      ? (ERROR_MESSAGES[error.code] ?? error.message)
+      : undefined;
+
+  const handleSubmit = (values: EpisodeFormValues) => {
+    reset();
+    mutate({ title: values.title, content: values.content });
+  };
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">새 에피소드 작성</h1>
-      <textarea
-        className="w-full h-64 p-4 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none"
-        placeholder="내용을 입력하세요..."
+    <main>
+      <WriteForm
+        onSubmit={handleSubmit}
+        isPending={isPending}
+        errorMessage={errorMessage}
       />
-    </div>
+    </main>
   );
-};
-export default WritePage;
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,21 @@
+export type ErrorCode =
+  | 'NETWORK_ERROR'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'RATE_LIMITED'
+  | 'VALIDATION_ERROR'
+  | 'SERVER_ERROR'
+  | 'UNKNOWN_ERROR';
+
+export class AppError extends Error {
+  constructor(
+    public code: ErrorCode,
+    public message: string,
+    public status?: number,
+    public originalError?: any,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,16 @@
+import { Endpoints } from '@octokit/types';
+
+export type GitHubIssueResponse =
+  Endpoints['GET /repos/{owner}/{repo}/issues']['response']['data'][number];
+
+export interface CreateEpisodeRequest {
+  title: string;
+  body: string;
+  labels?: string[];
+}
+
+export interface UpdateEpisodeRequest {
+  title?: string;
+  body?: string;
+  state?: 'open' | 'closed';
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -14,3 +14,13 @@ export interface UpdateEpisodeRequest {
   body?: string;
   state?: 'open' | 'closed';
 }
+
+export interface GitHubErrorResponse {
+  message: string;
+  errors?: Array<{
+    resource: string;
+    field: string;
+    code: string;
+  }>;
+  documentation_url?: string;
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,7 +1,16 @@
-import { Endpoints } from '@octokit/types';
-
-export type GitHubIssueResponse =
-  Endpoints['GET /repos/{owner}/{repo}/issues']['response']['data'][number];
+export interface GitHubIssueResponse {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  state: 'open' | 'closed';
+  created_at: string;
+  updated_at: string;
+  comments: number;
+  labels?: Array<{ id?: number; name: string; color?: string }>;
+  pull_request?: unknown;
+  _isOptimistic?: boolean;
+}
 
 export interface CreateEpisodeRequest {
   title: string;

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,7 +1,6 @@
 import { ERROR_CODE_MAP } from '../enums/error';
 import { AppError, ErrorCode } from '../types/error';
 
-// GitHub API 응답 → AppError 변환
 export async function parseGithubError(response: Response): Promise<AppError> {
   let message = `HTTP ${response.status}`;
   try {

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,17 @@
+import { ERROR_CODE_MAP } from '../enums/error';
+import { AppError, ErrorCode } from '../types/error';
+
+// GitHub API 응답 → AppError 변환
+export async function parseGithubError(response: Response): Promise<AppError> {
+  let message = `HTTP ${response.status}`;
+  try {
+    const body = await response.json();
+    message = body.message ?? message;
+  } catch {}
+
+  const code: ErrorCode =
+    ERROR_CODE_MAP[response.status] ??
+    (response.status >= 500 ? 'SERVER_ERROR' : 'UNKNOWN_ERROR');
+
+  return new AppError(code, message, response.status);
+}

--- a/src/utils/fetchClient.ts
+++ b/src/utils/fetchClient.ts
@@ -1,16 +1,15 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { parseGithubError } from './errorHandler';
 
 export const createClient = (config: AxiosRequestConfig): AxiosInstance => {
   const instance = axios.create({
     timeout: 10000,
     ...config,
   });
-
   instance.interceptors.response.use(
     (response) => response,
     (error) => {
-      console.error('API Error:', error.response?.data || error.message);
-      return Promise.reject(error);
+      return Promise.reject(parseGithubError(error));
     },
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,7 +3690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.2":
+"csstype@npm:^3.1.3, csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -4884,6 +4884,15 @@ __metadata:
     define-properties: "npm:^1.2.1"
     gopd: "npm:^1.0.1"
   checksum: 10c0/9d156f313af79d80b1566b93e19285f481c591ad6d0d319b4be5e03750d004dde40a39a0f26f7e635f9007a3600802f53ecd85a759b86f109e80a5f705e01846
+  languageName: node
+  linkType: hard
+
+"goober@npm:^2.1.16":
+  version: 2.1.18
+  resolution: "goober@npm:2.1.18"
+  peerDependencies:
+    csstype: ^3.0.10
+  checksum: 10c0/de9bf7b6f57417900afac81a479b85d8c0bcb0322ba8b174f9287d10e7891ba7e33db5fe2b0cdd75281c69130e76eb0c694345acf45ea57e4e4a2db8e4c4f021
   languageName: node
   linkType: hard
 
@@ -7639,6 +7648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-hot-toast@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "react-hot-toast@npm:2.6.0"
+  dependencies:
+    csstype: "npm:^3.1.3"
+    goober: "npm:^2.1.16"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 10c0/c25652e0a477ab501b365a6a2d20b314275a1d9963dd56a9803972d602845f0d44ade2c3345cd66ccd251d62e2e5a10001a55fd80fa183c0e41343f3780ffa9f
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -7754,6 +7776,7 @@ __metadata:
     prettier: "npm:^3.8.3"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
+    react-hot-toast: "npm:^2.6.0"
     react-markdown: "npm:^10.1.0"
     react-router-dom: "npm:^7.14.0"
     react-syntax-highlighter: "npm:^16.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,6 +1751,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/openapi-types@npm:^27.0.0":
+  version: 27.0.0
+  resolution: "@octokit/openapi-types@npm:27.0.0"
+  checksum: 10c0/602d1de033da180a2e982cdbd3646bd5b2e16ecf36b9955a0f23e37ae9e6cb086abb48ff2ae6f2de000fce03e8ae9051794611ae4a95a8f5f6fb63276e7b8e31
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "@octokit/types@npm:16.0.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^27.0.0"
+  checksum: 10c0/b8d41098ba6fc194d13d641f9441347e3a3b96c0efabac0e14f57319340a2d4d1c8676e4cb37ab3062c5c323c617e790b0126916e9bf7b201b0cced0826f8ae2
+  languageName: node
+  linkType: hard
+
 "@peculiar/asn1-cms@npm:^2.6.0, @peculiar/asn1-cms@npm:^2.6.1":
   version: 2.6.1
   resolution: "@peculiar/asn1-cms@npm:2.6.1"
@@ -7712,6 +7728,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.28.5"
     "@babel/preset-typescript": "npm:^7.28.5"
     "@eslint/js": "npm:^10.0.1"
+    "@octokit/types": "npm:^16.0.0"
     "@tailwindcss/postcss": "npm:^4.2.2"
     "@tanstack/react-query": "npm:^5.96.2"
     "@tanstack/react-query-devtools": "npm:^5.96.2"


### PR DESCRIPTION
### 배포 URL로 접속하기
- https://ansmeer008.github.io/read-me/
- github 메인 페이지 인풋에서 본인의 github 토큰을 입력하시면 기능을 사용할 수 있습니다.

### api 인터페이스 선언
- github API response, req에 대한 타입 구조 선언 
  - 처음에는 octokit을 사용해서 타입을 선언하고자 타입 패키지를 설치했으나 커스텀 형태로 진행 & 필요한 property를 명시적으로 보여주기 위해 직접 선언으로 변경 


### 에러 처리
- 에러 코드 타입, 에러 클래스 선언
- errorHandler > parseGithubError 함수를 통해 raw 에러 데이터를 선언된 에러 코드 타입으로 변환해 넘기는 처리 
-fetchClient에서는 토스트 처리는 하지 않음. UI 단에서 할 수 있도록 단순히 throw error만 해주는 정도로.


### CRUD 바인딩, 낙관적 업데이트 처리 
- [리스트 > 상세 페이지] 로 이어지는 흐름에서 낙관적 업데이트 처리를 위해 글 등록/수정/삭제 시 useOptimisticMutation 훅을 사용해 처리함
  - 리프레시 시점이 불명확하여 polling을 이용해서 list api sync를 맞추는 `useSyncAfterMutation` 훅 생성
- UI/UX적으로도 반영 중이라는 표기를 제공함, 상세 페이지에서 접근 가능한 수정/삭제 버튼은 실제로 db에 반영된 경우에만 적용되도록 처리
